### PR TITLE
Ability to specify different Worker username

### DIFF
--- a/jupyterhub_files/spawner.py
+++ b/jupyterhub_files/spawner.py
@@ -47,7 +47,7 @@ logging.basicConfig(level=logging.INFO)
 class RemoteCmdExecutionError(Exception): pass
 env.abort_exception = RemoteCmdExecutionError
 env.abort_on_prompts = True
-FABRIC_DEFAULTS = {"user":SERVER_PARAMS["SERVER_USERNAME"],
+FABRIC_DEFAULTS = {"user":SERVER_PARAMS["WORKER_USERNAME"],
                    "key_filename":"/home/%s/.ssh/%s" % (SERVER_PARAMS["SERVER_USERNAME"], SERVER_PARAMS["KEY_NAME"])}
 
 FABRIC_QUIET = True

--- a/launch_cluster/instance_config.json
+++ b/launch_cluster/instance_config.json
@@ -6,6 +6,7 @@
 "CUSTOM_WORKER_AMI": "",
 "SERVER_USERNAME": "ubuntu",
 "REGION": "us-east-1",
+"WORKER_USERNAME": "ubuntu",
 "SERVER_OWNER": "",
 "IGNORE_PERMISSIONS": "false"
 }

--- a/launch_cluster/launch.py
+++ b/launch_cluster/launch.py
@@ -157,7 +157,8 @@ def setup_manager(server_params, manager_ip_address):
     sudo("service jupyterhub start", pty=False)
     # move our cron script into place
     sudo("cp /etc/jupyterhub/jupyterhub_cron.txt /etc/cron.d/jupyterhub_cron")
-    logger.info("Manager server successfully launched. Please wait 15 minutes for the worker server AMI image to become available. No worker servers (and thus, no user sessions) can be launched until the AMI is available.")
+    if not config.custom_worker_ami:
+        logger.info("Manager server successfully launched. Please wait 15 minutes for the worker server AMI image to become available. No worker servers (and thus, no user sessions) can be launched until the AMI is available.")
     # TODO: generate ssl files and enable jupyterhub ssl
 
 


### PR DESCRIPTION
We have a CentOS box that is preconfigured with our extensions for JupyterLab. This patch adds the ability to specify a different Worker username versus the Manager's username. I also included a quick conditional statement to silence the worker AMI creation line if it wasn't actually creating one, which confused me at first. 