### PR TITLE
Resolve issues with setup_user() process in spawner

### DIFF
--- a/jupyterhub_files/setup_jupyteruser.sh
+++ b/jupyterhub_files/setup_jupyteruser.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# This script is for setting up a jupyter notebook user on a worker.
+#
+# Usage:
+#
+#   JUPYTERUSER=jharvard JUPYTERDEVICE=xvdf ./setup_jupyteruser.sh
+#
+
+# Redirect stdout and stderr to the syslog
+exec 1> >(logger -s -t $(basename $0)) 2>&1
+
+# Ensure this script is run as root
+if [[ $EUID -ne 0 ]]; then
+	echo "This script must be run as root" 
+	exit 1
+fi
+
+# Ensure that a username is specified
+if [ -z "$JUPYTERUSER" ]; then
+	echo "JUPYTERUSER is a required parameter (e.g. 12345678). Aborting!"
+	exit 1
+else
+	echo "JUPYTERUSER is $JUPYTERUSER"
+fi
+
+### --------------------------------------------------
+### Mount EBS home volume if a device is specified
+
+if [ -n "$JUPYTERDEVICE" ]; then
+    echo "JUPYTERDEVICE is $JUPYTERDEVICE"
+    if lsblk --noheadings --fs /dev/$JUPYTERDEVICE | grep xfs &>/dev/null; then
+        echo "Skip: already created filesystem"
+    else
+        echo "Creating filesystem..."
+        mkfs.xfs /dev/$JUPYTERDEVICE
+    fi
+
+    if [ -e "/jupyteruser" ]; then
+        echo "Skip: already created jupyteruser directory to mount device"
+    else
+        echo "Creating jupyteruser directory as mount point for device"
+        mkdir -p /jupyteruser
+    fi
+
+    if grep -q "/dev/$JUPYTERDEVICE" /etc/fstab; then
+        echo "Skip: already added device to /etc/fstab"
+    else
+        echo "Adding device to /etc/fstab..."
+        echo "/dev/$JUPYTERDEVICE /jupyteruser xfs defaults 1 1" >> /etc/fstab
+    fi
+
+    if grep -q "/dev/$JUPYTERDEVICE" /proc/mounts; then
+        echo "Skip: already mounted"
+    else
+        echo "Mounting volume..."
+        mount -a
+    fi
+else
+	echo "JUPYTERDEVICE not specified for the user home volume. Skipping associated setup."
+fi
+
+### --------------------------------------------------
+### Setup the user account and home directory
+
+if id -u $JUPYTERUSER &>/dev/null; then
+	echo "Skip: user account already exists"
+else
+	echo "Adding new user account..."
+	useradd -d /home/$JUPYTERUSER $JUPYTERUSER -s /bin/bash  &>/dev/null
+fi
+
+if [ -d "/jupyteruser/$JUPYTERUSER" ]; then
+	echo "Skip: contents of ubuntu home directory already copied"
+else
+	echo "Copying ubuntu home directory to new user home directory..."
+	cp -R /home/ubuntu /jupyteruser/$JUPYTERUSER
+fi
+
+if [ -L "/home/$JUPYTERUSER" ]; then
+	echo "Skip: home directory already symlinked to mount point"
+else
+	echo "Symlinking home directory to mount point..."
+	ln -s /jupyteruser/$JUPYTERUSER /home/$JUPYTERUSER
+fi
+
+if [ -e "/etc/sudoers.d/$JUPYTERUSER" ]; then 
+	echo "Skip: sudo privilege already setup"
+else
+	echo "Granting sudo privileges to user without requiring a password..."
+	echo " $JUPYTERUSER ALL=(ALL) NOPASSWD:ALL " > /etc/sudoers.d/$JUPYTERUSER
+fi
+
+echo "Setting permissions on user home directory..."
+chown -R $JUPYTERUSER.$JUPYTERUSER /home/$JUPYTERUSER /jupyteruser/$JUPYTERUSER
+exit 0


### PR DESCRIPTION
This PR resolves issues with the `setup_user()` process in the spawner.

If the user setup process fails to complete successfully, then it's impossible for the spawner to start the remote notebook server, even though it will keep trying and failing. The spawner does not check to see if the user was setup successfully after the initial launch (e.g. when it is _new_), so the problem goes unfixed and the user continues to see 500 errors as a result of their notebook server not starting.

The solution proposed here does two things:

1. Implements a `is_user_setup()` method to check if the user setup process completed successfully. It checks to see if the user account was created, the home directory was created, and if the permissions are valid on the home directory.
2. Refactors `setup_user()` method to upload a shell script to the worker instance to perform the setup process and then executes the script with the required parameters (e.g. username and volume to mount). Note that one important property of the shell script is that it is _idempotent_, and will only make changes as necessary to achieve the desired end state. Running it multiple times should yield the same result as running it once successfully.

A possible next iteration of this solution is to have this shell script run as part of the **userdata** of the new worker instance.  This would be a very clean approach, since this should only need to be run once rather than every time a worker is started. For this to work, it would be necessary to have the **userdata** deliberately disable the ssh server prior to running the setup process, and then enable it when finished. This would prevent the spawner from prematurely trying to start the notebook server until the setup process has completed.

The current solution has one advantage over the userdata approach, which is that it addresses existing worker instances that are in varying states with respect to user setup. Therefore, we are proposing this solution first, with the goal in mind of transitioning to userdata later.

@farassadek @joshuagetega